### PR TITLE
feat(display): TFT display standby / timeout feature

### DIFF
--- a/src/display/DisplayBase.cpp
+++ b/src/display/DisplayBase.cpp
@@ -29,6 +29,7 @@ DisplayBase::DisplayBase()
   this->system = gSystem;
   this->timeout = 0u;
   this->brightness = 100u;
+  this->timeoutbrightness = 5u;
 }
 
 void DisplayBase::init()
@@ -47,6 +48,7 @@ void DisplayBase::saveConfig()
   json["orientation"] = (uint16_t)this->orientation;
   json["timeout"] = this->timeout;
   json["brightness"] = this->brightness;
+  json["timeoutbrightness"] = this->timeoutbrightness;
   Settings::write(kDisplay, json);
 }
 
@@ -63,9 +65,11 @@ void DisplayBase::loadConfig()
     if (json.containsKey("orientation"))
       this->orientation = (DisplayOrientation)json["orientation"].as<uint16_t>();
     if (json.containsKey("timeout"))
-      this->timeout = json["timeout"].as<uint16_t>();
+      this->timeout = json["timeout"].as<uint32_t>();
     if (json.containsKey("brightness"))
       this->brightness = json["brightness"].as<uint8_t>();
+    if (json.containsKey("timeoutbrightness"))
+      this->timeoutbrightness = json["timeoutbrightness"].as<uint8_t>();
   }
 }
 

--- a/src/display/DisplayBase.h
+++ b/src/display/DisplayBase.h
@@ -51,8 +51,9 @@ protected:
   boolean blocked;
   DisplayOrientation orientation;
   String modelName;
-  uint16_t timeout;
-  uint8_t brightness;
+  uint32_t timeout;
+  uint8_t brightness;   // USER BRIGHTNESS
+  uint8_t timeoutbrightness;
 };
 
 extern DisplayBase *gDisplay;

--- a/src/display/tft/DisplayTft.cpp
+++ b/src/display/tft/DisplayTft.cpp
@@ -34,14 +34,12 @@ extern const uint16_t DisplayTftCharged[];
 extern const uint16_t DisplayTftCharging[];
 extern const uint16_t DisplayTftStartScreenImg[25400];
 
-// DisplayTft.cpp
-
 static const uint32_t TIMEOUT_VALUES[] = {
-    0,          // AUS
+    0,          // OFF
     30000,      // 30 s
     60000,      // 60 s
     120000,     // 120 s
-    300000      // 30000 s
+    300000,     // 300 s
 };
 
 static constexpr uint8_t TIMEOUT_VALUE_COUNT =

--- a/src/display/tft/DisplayTft.cpp
+++ b/src/display/tft/DisplayTft.cpp
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
     Copyright (C) 2020  Martin Koerner
 
     This program is free software: you can redistribute it and/or modify
@@ -13,9 +13,9 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    
+
     HISTORY: Please refer Github History
-    
+
 ****************************************************/
 #include "DisplayTft.h"
 #include "Settings.h"
@@ -25,6 +25,7 @@
 #include "lvScreen.h"
 #include "lvTheme.h"
 #include "PCA9533.h"
+#include "ArduinoLog.h"
 
 #define TFT_TOUCH_CALIBRATION_ARRAY_SIZE 5u
 #define I2C_BRIGHTNESS_CONTROL_ADDRESS 0x0D
@@ -32,6 +33,38 @@
 extern const uint16_t DisplayTftCharged[];
 extern const uint16_t DisplayTftCharging[];
 extern const uint16_t DisplayTftStartScreenImg[25400];
+
+// DisplayTft.cpp
+
+static const uint32_t TIMEOUT_VALUES[] = {
+    0,          // AUS
+    30000,      // 30 s
+    60000,      // 60 s
+    120000,     // 120 s
+    300000      // 30000 s
+};
+
+static constexpr uint8_t TIMEOUT_VALUE_COUNT =
+    sizeof(TIMEOUT_VALUES) / sizeof(TIMEOUT_VALUES[0]);
+
+void DisplayTft::setTimeoutIndex(uint8_t index)
+{
+  if (index >= TIMEOUT_VALUE_COUNT) return; // ungültiger Index
+  setTimeout(TIMEOUT_VALUES[index]);
+}
+
+uint8_t DisplayTft::getTimeoutIndex() const
+{
+  for (uint8_t i = 0; i < TIMEOUT_VALUE_COUNT; i++)
+  {
+    if (TIMEOUT_VALUES[i] == timeout)
+    {
+      return i;
+    }
+  }
+
+  return 0; // Fallback → AUS
+}
 
 TFT_eSPI DisplayTft::tft = TFT_eSPI();
 
@@ -43,7 +76,7 @@ DisplayTft::DisplayTft()
 
 void DisplayTft::hwInit()
 {
-  DisplayTft::setBrightness(0u);
+  DisplayTft::applyBrightness(0u);
 
   tft.init();
   tft.setRotation(1);
@@ -52,7 +85,7 @@ void DisplayTft::hwInit()
   tft.pushImage(33, 70, 254, 100, DisplayTftStartScreenImg);
 
   // configure dimming IC
-  this->setBrightness(100u);
+  this->applyBrightness(100u);
 
   // configure dimming IC (old TFT, aktuell noch in gebrauch)
   // arduino-esp32 2.x: ESP-IDF I2C driver has ~10ms overhead per failed transaction;
@@ -116,6 +149,7 @@ boolean DisplayTft::initDisplay()
   lv_indev_drv_init(&indev_drv);
   indev_drv.type = LV_INDEV_TYPE_POINTER;
   indev_drv.read_cb = DisplayTft::touchRead;
+  indev_drv.user_data = this;
   lv_indev_drv_register(&indev_drv);
 
   lv_theme_t *theme = lvTheme_Init(lv_color_hex(0x0aa5c4), lv_theme_get_color_secondary(),
@@ -126,7 +160,14 @@ boolean DisplayTft::initDisplay()
   lv_theme_set_act(theme);
 
   lvScreen_Open(lvScreenType::Home);
-  setBrightness(this->brightness);
+
+  isTimeout = false;
+  fadeStep = 1;
+  fadeIntervalMs = 20;
+  lastFadeMillis = 0;
+  targetBrightness = this->brightness;
+  applyBrightness(this->brightness);
+  onUserActivity();
 
   return true;
 }
@@ -168,19 +209,93 @@ void DisplayTft::calibrate()
   prefs.end();
 }
 
-void DisplayTft::setBrightness(uint8_t brightness)
+void DisplayTft::setTimeout(uint32_t newTimeout)
 {
-  this->brightness = brightness;
-  int value = (int)(this->brightness * 2.55);
+  this->timeout = newTimeout;
+
+  // Timeout komplett deaktiviert
+  if (timeout == 0)
+  {
+    isTimeout = false;
+
+    // Display sicher aktivieren
+    applyBrightness(this->brightness);
+    targetBrightness = this->brightness;
+
+    return;
+  }
+
+  // Timeout aktiv (neu gesetzt oder geändert)
+  lastActivityMillis = millis();
+
+  // Falls wir gerade im Timeout waren → aufwecken
+  if (isTimeout)
+  {
+    isTimeout = false;
+    applyBrightness(this->brightness);
+    targetBrightness = this->brightness;
+  }
+}
+
+uint32_t DisplayTft::getTimeout()
+{
+  return this->timeout;
+}
+
+void DisplayTft::setUserBrightness(uint8_t setBrightness)
+{
+  this->brightness = setBrightness;
+
+  // nur direkt anwenden, wenn wir NICHT im Timeout sind
+  if (!isTimeout)
+  {
+    applyBrightness(this->brightness);
+  }
+}
+
+uint8_t DisplayTft::getUserBrightness()
+{
+  return this->brightness;
+}
+
+void DisplayTft::applyBrightness(uint8_t brightness)
+{
+  currentBrightness = brightness;
+  int value = (int)(brightness * 2.55);
 
   Wire.beginTransmission(I2C_BRIGHTNESS_CONTROL_ADDRESS);
   Wire.write(value);
   Wire.endTransmission();
 }
 
-uint8_t DisplayTft::getBrightness()
+void DisplayTft::setTargetBrightness(uint8_t brightness)
 {
-  return this->brightness;
+  targetBrightness = brightness;
+}
+
+void DisplayTft::updateFade()
+{
+  if (currentBrightness == targetBrightness)
+  {
+    return; // nichts zu tun
+  }
+
+  uint32_t now = millis();
+  if (now - lastFadeMillis < fadeIntervalMs)
+  {
+    return;
+  }
+
+  lastFadeMillis = now;
+
+  if (currentBrightness < targetBrightness)
+  {
+    applyBrightness(currentBrightness + fadeStep);
+  }
+  else if (currentBrightness > targetBrightness)
+  { // wird aktuell nicht benoetigt, da direktes Aufwachen
+    applyBrightness(currentBrightness - fadeStep);
+  }
 }
 
 void DisplayTft::drawCharging()
@@ -228,7 +343,7 @@ void DisplayTft::task(void *parameter)
 
   for (;;)
   {
-    //Serial.printf("DisplayTft::task, highWaterMark: %d\n", uxTaskGetStackHighWaterMark(NULL));
+    // Serial.printf("DisplayTft::task, highWaterMark: %d\n", uxTaskGetStackHighWaterMark(NULL));
 
     display->update();
     // Wait for the next cycle.
@@ -250,6 +365,8 @@ void DisplayTft::update()
   }
 
   lvScreen_Update();
+  handleDisplayTimeout();
+  updateFade();
 
   currentMillis = millis();
   lv_tick_inc(currentMillis - lastMillis);
@@ -272,27 +389,86 @@ void DisplayTft::displayFlushing(lv_disp_drv_t *disp, const lv_area_t *area, lv_
 
 bool DisplayTft::touchRead(lv_indev_drv_t *indev_driver, lv_indev_data_t *data)
 {
+  auto *self = static_cast<DisplayTft *>(indev_driver->user_data);
   uint16_t touchX, touchY;
+  bool touched = self->tft.getTouch(&touchX, &touchY);
 
-  bool touched = tft.getTouch(&touchX, &touchY);
-
+  // kein Touch gefunden
   if (!touched)
   {
+    data->state = LV_INDEV_STATE_REL;
+    self->ignoreTouchUntilRelease = false;
     return false;
   }
 
+  // Timeout aktiv? → nur aufwecken
+  if (self->isTimeout)
+  {
+    self->onUserActivity(); // Helligkeit zurücksetzen
+    self->ignoreTouchUntilRelease = true;
+    data->state = LV_INDEV_STATE_REL;
+    return false; // Touch NICHT an LVGL geben
+  }
+
+  // nach Wake-up: Touch noch gesperrt?
+  if (self->ignoreTouchUntilRelease)
+  {
+    data->state = LV_INDEV_STATE_REL;
+    return false;
+  }
+
+  // normaler Touch
+  self->onUserActivity();
+
   if (touchX > 320 || touchY > 240)
   {
-    Serial.printf("Touch coordinates issue: x: %d, y: %d\n", touchX, touchY);
+    Log.notice("Touch coordinates issue: x: %d, y: %d" CR, touchX, touchY);
+    data->state = LV_INDEV_STATE_REL;
+    return false;
   }
-  else
-  {
 
-    data->state = touched ? LV_INDEV_STATE_PR : LV_INDEV_STATE_REL;
-
-    data->point.x = touchX;
-    data->point.y = touchY;
-  }
+  data->state = LV_INDEV_STATE_PR;
+  data->point.x = touchX;
+  data->point.y = touchY;
 
   return false;
+}
+
+void DisplayTft::handleDisplayTimeout()
+{
+  // Timeout deaktiviert
+  if (timeout == 0)
+  {
+    return;
+  }
+
+  uint32_t now = millis();
+
+  if (!isTimeout && (now - lastActivityMillis >= timeout))
+  {
+    setTargetBrightness(this->timeoutbrightness);
+    isTimeout = true;
+  }
+}
+
+void DisplayTft::onUserActivity()
+{
+  lastActivityMillis = millis();
+
+  // Timeout deaktiviert → sicherstellen, dass Display aktiv ist
+  if (timeout == 0)
+  {
+    isTimeout = false;
+    applyBrightness(this->brightness);
+    targetBrightness = this->brightness;
+    return;
+  }
+
+  if (isTimeout)
+  {
+    applyBrightness(this->brightness); // ZURÜCK ZUM USER-WERT
+    isTimeout = false;
+    // Zielwert anpassen, damit updateFade() nichts mehr tut
+    targetBrightness = this->brightness;
+  }
 }

--- a/src/display/tft/DisplayTft.cpp
+++ b/src/display/tft/DisplayTft.cpp
@@ -122,7 +122,7 @@ boolean DisplayTft::initDisplay()
 
   if (this->disabled)
   {
-    Serial.printf("DisplayTft::init: display disabled\n");
+    Log.notice("DisplayTft::init: display disabled" CR);
     return true;
   }
 

--- a/src/display/tft/DisplayTft.h
+++ b/src/display/tft/DisplayTft.h
@@ -35,17 +35,34 @@ public:
   void hwInit();
   void update();
   void calibrate();
-  void setBrightness(uint8_t brightness);
-  uint8_t getBrightness();
+  void setUserBrightness(uint8_t setBrightness);
+  void setTimeout(uint32_t newTimeout);
+  uint8_t getUserBrightness();
+  uint32_t getTimeout();
   static void drawCharging();
+  void onUserActivity();
+  void setTimeoutIndex(uint8_t index);
+  uint8_t getTimeoutIndex() const;
 
 private:
   boolean initDisplay();
   boolean isCalibrated();
   static void task(void *parameter);
+  void applyBrightness(uint8_t brightness);
+  void setTargetBrightness(uint8_t brightness);
+  void updateFade();
+  bool ignoreTouchUntilRelease = false;
+  uint8_t targetBrightness;
+  uint8_t currentBrightness;
+  uint32_t lastFadeMillis;
+  uint16_t fadeIntervalMs;
+  uint8_t fadeStep;
+  uint32_t lastActivityMillis;
+  bool isTimeout;
 
   static void displayFlushing(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p);
   static bool touchRead(lv_indev_drv_t *indev_driver, lv_indev_data_t *data);
+  void handleDisplayTimeout();
 
   static TFT_eSPI tft;
   lv_disp_buf_t lvDispBuffer;

--- a/src/display/tft/lvDisplay.cpp
+++ b/src/display/tft/lvDisplay.cpp
@@ -1,4 +1,4 @@
-/*************************************************** 
+/***************************************************
     Copyright (C) 2020  Martin Koerner
 
     This program is free software: you can redistribute it and/or modify
@@ -13,9 +13,9 @@
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-    
+
     HISTORY: Please refer Github History
-    
+
 ****************************************************/
 #include "lvDisplay.h"
 #include "lvScreen.h"
@@ -25,11 +25,19 @@
 
 LV_FONT_DECLARE(Font_Gothic_A1_Medium_h16);
 LV_FONT_DECLARE(Font_Nano_h24);
+LV_FONT_DECLARE(Font_Roboto_Medium_h28);
+LV_FONT_DECLARE(Font_Roboto_Medium_h80);
 
 static lvDisplayType lvDisplay = {NULL};
 
+static void lvDisplay_CreateTabBrightness(void);
+static void lvDisplay_CreateTabTimeout(void);
+
 static void lvDisplay_BtnClose(lv_obj_t *obj, lv_event_t event);
 static void lvDisplay_BrightnessEvent(lv_obj_t *obj, lv_event_t event);
+static void lvDisplay_TimeoutMinusEvent(lv_obj_t *obj, lv_event_t event);
+static void lvDisplay_TimeoutPlusEvent(lv_obj_t *obj, lv_event_t event);
+static void lvDisplay_UpdateTimeoutLabel(void);
 
 void lvDisplay_Create(void *userData)
 {
@@ -39,14 +47,14 @@ void lvDisplay_Create(void *userData)
   lvDisplay.screen = lv_obj_create(NULL, NULL);
   lv_obj_set_size(lvDisplay.screen, LV_HOR_RES, LV_VER_RES);
 
-  lv_obj_t *tabview = lv_tabview_create(lvDisplay.screen, NULL);
-  lv_obj_set_style_local_pad_top(tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_pad_bottom(tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_pad_top(tabview, LV_TABVIEW_PART_TAB_BTN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_pad_bottom(tabview, LV_TABVIEW_PART_TAB_BTN, LV_STATE_DEFAULT, 5);
-  lv_obj_set_style_local_pad_right(tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, LV_HOR_RES - 50);
-  lv_tabview_set_anim_time(tabview, 0);
-  lv_obj_set_style_local_text_font(tabview, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, &Font_Nano_h24);
+  lvDisplay.tabview = lv_tabview_create(lvDisplay.screen, NULL);
+  lv_obj_set_style_local_pad_top(lvDisplay.tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_pad_bottom(lvDisplay.tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_pad_top(lvDisplay.tabview, LV_TABVIEW_PART_TAB_BTN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_pad_bottom(lvDisplay.tabview, LV_TABVIEW_PART_TAB_BTN, LV_STATE_DEFAULT, 5);
+  lv_obj_set_style_local_pad_right(lvDisplay.tabview, LV_TABVIEW_PART_TAB_BG, LV_STATE_DEFAULT, LV_HOR_RES / 3);
+  lv_tabview_set_anim_time(lvDisplay.tabview, 0);
+  lv_obj_set_style_local_text_font(lvDisplay.tabview, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, &Font_Nano_h24);
 
   lv_obj_t *btn = lv_btn_create(lvDisplay.screen, NULL);
   lv_obj_set_event_cb(btn, lvDisplay_BtnClose);
@@ -55,29 +63,79 @@ void lvDisplay_Create(void *userData)
   lv_obj_set_pos(btn, LV_DPX(335), LV_DPX(12));
   lv_obj_set_size(btn, LV_DPX(50), LV_DPX(35));
 
-  /* create display tab */
-  lv_obj_t *tab = lv_tabview_add_tab(tabview, "r");
+  lvDisplay_CreateTabBrightness();
+  lvDisplay_CreateTabTimeout();
 
+  lvDisplay_Update(true);
+
+  lv_scr_load(lvDisplay.screen);
+}
+
+void lvDisplay_CreateTabBrightness(void)
+{
+
+  DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
+  
+  /* create display tab */
+  lv_obj_t *tab = lv_tabview_add_tab(lvDisplay.tabview, "t");
+
+  /* create container */
   lv_obj_t *cont = lv_cont_create(tab, NULL);
-  lv_cont_set_fit(cont, LV_FIT_PARENT);
   lv_cont_set_layout(cont, LV_LAYOUT_ROW_MID);
+  lv_cont_set_fit(cont, LV_FIT_PARENT);
   lv_obj_set_style_local_border_width(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
   lv_obj_set_style_local_radius(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
   lv_obj_set_style_local_pad_left(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 60);
 
+  /* ===== Brightness UI ===== */
   lvDisplay.sliderBrightness = lv_slider_create(cont, NULL);
   lv_obj_set_width(lvDisplay.sliderBrightness, 210);
   lv_slider_set_range(lvDisplay.sliderBrightness, 1, 10);
-  lv_slider_set_value(lvDisplay.sliderBrightness, (int16_t)(tftDisplay->getBrightness() / 10u), LV_ANIM_OFF);
+  lv_slider_set_value(lvDisplay.sliderBrightness, (int16_t)(tftDisplay->getUserBrightness() / 10u), LV_ANIM_OFF);
   lv_obj_set_event_cb(lvDisplay.sliderBrightness, lvDisplay_BrightnessEvent);
   lv_obj_set_style_local_value_font(lvDisplay.sliderBrightness, LV_SWITCH_PART_BG, LV_STATE_DEFAULT, &Font_Nano_h24);
   lv_obj_set_style_local_value_str(lvDisplay.sliderBrightness, LV_SWITCH_PART_BG, LV_STATE_DEFAULT, "t");
   lv_obj_set_style_local_value_align(lvDisplay.sliderBrightness, LV_SWITCH_PART_BG, LV_STATE_DEFAULT, LV_ALIGN_OUT_LEFT_MID);
   lv_obj_set_style_local_value_ofs_x(lvDisplay.sliderBrightness, LV_SWITCH_PART_BG, LV_STATE_DEFAULT, -20);
+}
 
-  lvDisplay_Update(true);
+void lvDisplay_CreateTabTimeout(void) 
+{
 
-  lv_scr_load(lvDisplay.screen);
+  DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
+
+  /* create display tab */
+  lv_obj_t *tab = lv_tabview_add_tab(lvDisplay.tabview, "r");
+
+  /* create container */
+  lv_obj_t *cont = lv_cont_create(tab, NULL);
+  lv_cont_set_fit(cont, LV_FIT_PARENT);
+  lv_cont_set_layout(cont, LV_LAYOUT_PRETTY_MID);                                         // LV_LAYOUT_ROW_MID
+  lv_obj_set_style_local_border_width(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 0);
+  lv_obj_set_style_local_radius(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
+
+  /* ===== Timeout UI ===== */
+  
+  /* Label */
+  lvDisplay.labelTimeout = lv_label_create(cont, NULL);
+  lv_obj_align(lvDisplay.labelTimeout, NULL, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_set_style_local_text_font(lvDisplay.labelTimeout, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &Font_Roboto_Medium_h28);
+
+  /* Minus */
+  lv_obj_t *btnDec = lv_btn_create(cont, NULL);
+  lv_obj_set_size(btnDec, 100, 50);
+  lv_obj_set_style_local_value_str(btnDec, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_SYMBOL_MINUS);
+  lv_obj_set_event_cb(btnDec, lvDisplay_TimeoutMinusEvent);
+
+  /* Plus */
+  lv_obj_t *btnInc = lv_btn_create(cont, NULL);
+  lv_obj_set_size(btnInc, 100, 50);
+  lv_obj_set_style_local_value_str(btnInc, LV_BTN_PART_MAIN, LV_STATE_DEFAULT, LV_SYMBOL_PLUS);
+  lv_obj_set_event_cb(btnInc, lvDisplay_TimeoutPlusEvent);
+  
+  /* Initialwert aus Display holen */
+  lvDisplay.timeoutIndex = tftDisplay->getTimeoutIndex();
+  lvDisplay_UpdateTimeoutLabel();
 }
 
 void lvDisplay_Update(boolean forceUpdate)
@@ -105,6 +163,54 @@ void lvDisplay_BrightnessEvent(lv_obj_t *obj, lv_event_t event)
     DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
     int16_t value = lv_slider_get_value(obj);
 
-    tftDisplay->setBrightness((uint8_t)(value * 10u));
+    tftDisplay->setUserBrightness((uint8_t)(value * 10u));
   }
+}
+
+static void lvDisplay_UpdateTimeoutLabel(void)
+{
+  DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
+
+  uint32_t timeout = tftDisplay->getTimeout();
+
+  char buf[24];
+
+  if (timeout == 0)
+  {
+    snprintf(buf, sizeof(buf), "Timeout: OFF");
+  }
+  else
+  {
+    snprintf(buf, sizeof(buf), "Timeout: %u s", timeout / 1000UL);
+  }
+
+  lv_label_set_text(lvDisplay.labelTimeout, buf);
+}
+
+static void lvDisplay_TimeoutMinusEvent(lv_obj_t *obj, lv_event_t event)
+{
+  if (event != LV_EVENT_CLICKED)
+    return;
+
+  DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
+
+  if (lvDisplay.timeoutIndex > 0)
+  {
+    lvDisplay.timeoutIndex--;
+    tftDisplay->setTimeoutIndex(lvDisplay.timeoutIndex);
+    lvDisplay_UpdateTimeoutLabel();
+  }
+}
+
+static void lvDisplay_TimeoutPlusEvent(lv_obj_t *obj, lv_event_t event)
+{
+  if (event != LV_EVENT_CLICKED)
+    return;
+
+  DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
+
+  lvDisplay.timeoutIndex++;
+  tftDisplay->setTimeoutIndex(lvDisplay.timeoutIndex);
+  lvDisplay.timeoutIndex = tftDisplay->getTimeoutIndex(); // Clamp-Sicherheit
+  lvDisplay_UpdateTimeoutLabel();
 }

--- a/src/display/tft/lvDisplay.cpp
+++ b/src/display/tft/lvDisplay.cpp
@@ -26,7 +26,6 @@
 LV_FONT_DECLARE(Font_Gothic_A1_Medium_h16);
 LV_FONT_DECLARE(Font_Nano_h24);
 LV_FONT_DECLARE(Font_Roboto_Medium_h28);
-LV_FONT_DECLARE(Font_Roboto_Medium_h80);
 
 static lvDisplayType lvDisplay = {NULL};
 
@@ -73,9 +72,8 @@ void lvDisplay_Create(void *userData)
 
 void lvDisplay_CreateTabBrightness(void)
 {
-
   DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
-  
+
   /* create display tab */
   lv_obj_t *tab = lv_tabview_add_tab(lvDisplay.tabview, "t");
 
@@ -99,9 +97,8 @@ void lvDisplay_CreateTabBrightness(void)
   lv_obj_set_style_local_value_ofs_x(lvDisplay.sliderBrightness, LV_SWITCH_PART_BG, LV_STATE_DEFAULT, -20);
 }
 
-void lvDisplay_CreateTabTimeout(void) 
+void lvDisplay_CreateTabTimeout(void)
 {
-
   DisplayTft *tftDisplay = (DisplayTft *)gDisplay;
 
   /* create display tab */
@@ -115,7 +112,7 @@ void lvDisplay_CreateTabTimeout(void)
   lv_obj_set_style_local_radius(cont, LV_CONT_PART_MAIN, LV_STATE_DEFAULT, 10);
 
   /* ===== Timeout UI ===== */
-  
+
   /* Label */
   lvDisplay.labelTimeout = lv_label_create(cont, NULL);
   lv_obj_align(lvDisplay.labelTimeout, NULL, LV_ALIGN_CENTER, 0, 0);

--- a/src/display/tft/lvDisplay.h
+++ b/src/display/tft/lvDisplay.h
@@ -26,9 +26,14 @@ typedef struct lvDisplay
 {
 
   lv_obj_t *screen;
+  lv_obj_t *tabview;
   lv_obj_t *btnClose;
   lv_obj_t *labelBrightness;
   lv_obj_t *sliderBrightness;
+  lv_obj_t *labelTimeout;
+  lv_obj_t *btnDec;
+  lv_obj_t *btnInc;
+  uint8_t timeoutIndex;
 } lvDisplayType;
 
 void lvDisplay_Create(void *userData);

--- a/src/display/tft/lvDisplay.h
+++ b/src/display/tft/lvDisplay.h
@@ -24,15 +24,10 @@
 
 typedef struct lvDisplay
 {
-
   lv_obj_t *screen;
   lv_obj_t *tabview;
-  lv_obj_t *btnClose;
-  lv_obj_t *labelBrightness;
   lv_obj_t *sliderBrightness;
   lv_obj_t *labelTimeout;
-  lv_obj_t *btnDec;
-  lv_obj_t *btnInc;
   uint8_t timeoutIndex;
 } lvDisplayType;
 

--- a/src/display/tft/lvHome.cpp
+++ b/src/display/tft/lvHome.cpp
@@ -452,7 +452,13 @@ void lvHome_UpdateBatterySymbol(boolean forceUpdate)
   }
   else
   {
-    long symbolIndex = map(gSystem->battery->percentage, 0, 100, 0, LVHOME_SYMBOL_BATTERY_DISCHARGING_MAX_INDEX);
+    constexpr int SEGMENTS = LVHOME_SYMBOL_BATTERY_DISCHARGING_MAX_INDEX;
+
+    int percentage = constrain(gSystem->battery->percentage, 0, 100);
+    int segmentSize = 100 / SEGMENTS;
+    int symbolIndex = constrain((percentage + segmentSize - 1) / segmentSize, 0, SEGMENTS);
+
+    //long symbolIndex = map(gSystem->battery->percentage, 0, 100, 0, LVHOME_SYMBOL_BATTERY_DISCHARGING_MAX_INDEX);
     newBatterySymbol = batterySymbolText[symbolIndex];
   }
 

--- a/src/peripherie/Battery.cpp
+++ b/src/peripherie/Battery.cpp
@@ -126,6 +126,7 @@ void Battery::updatePowerPercentage()
     this->percentage = 100;
     break;
 
+  case PowerMode::Protection:
   case PowerMode::Battery:
     // Nach vollständiger Ladung 
     if (this->setreference > 0) // && this->voltage > 4000
@@ -141,13 +142,14 @@ void Battery::updatePowerPercentage()
     }
     // Freier Betrieb
     else {
+      // Nach Systemstart ohne Filterung
       if (millis() < BATTERYSTARTUP)
       {
         this->percentage = percraw;
       }
       else 
       {
-      // Gleitender Mittelwert / Filter
+      // Gleitender Mittelwert / Filter zum Ausgleich von schwankenden Messwerten
         int FF = 2;
         float newPerc = ((this->percentage * FF) + percraw) / (FF + 1.0);
         

--- a/src/peripherie/Battery.cpp
+++ b/src/peripherie/Battery.cpp
@@ -99,7 +99,7 @@ void Battery::updatePowerPercentage()
  
   // Polynom-Ansatz zur Berechnung der rohen Prozentzahl
   float rVol = this->voltage/1000.0;
-  float percraw = (1664.4 - 197.3*rVol)*rVol - 3408.0;
+  float percraw = (1688.8 - 200.0*rVol)*rVol - 3460.0;
 
   // auf 0–100% begrenzen
   percraw = constrain(percraw, 0, 100);
@@ -129,7 +129,7 @@ void Battery::updatePowerPercentage()
   case PowerMode::Protection:
   case PowerMode::Battery:
     // Nach vollständiger Ladung 
-    if (this->setreference > 0) // && this->voltage > 4000
+    if (this->setreference > 0 && this->voltage > 4000)
     {
       this->percentage = 100;
       if ((millis() - this->correction) > CORRECTIONTIME)

--- a/src/peripherie/Battery.cpp
+++ b/src/peripherie/Battery.cpp
@@ -94,13 +94,14 @@ void Battery::updatePowerPercentage()
   //Serial.println("Battery::updatePowerPercentage");
 
   // Calculate battery percentage
-  uint32_t percraw;
-  // linear
-  //percraw = ((this->voltage - this->min) * 100) / (this->max - this->min);
-  // polynom
-  float rVol = this->voltage/1000.0;
-  percraw = (1664.4 - 197.3*rVol)*rVol - 3408.0;
 
+  // Linear-Ansatz: float percraw = ((this->voltage - this->min) * 100) / (this->max - this->min);
+ 
+  // Polynom-Ansatz zur Berechnung der rohen Prozentzahl
+  float rVol = this->voltage/1000.0;
+  float percraw = (1664.4 - 197.3*rVol)*rVol - 3408.0;
+
+  // auf 0–100% begrenzen
   percraw = constrain(percraw, 0, 100);
 
   // Korrektur
@@ -127,7 +128,7 @@ void Battery::updatePowerPercentage()
 
   case PowerMode::Battery:
     // Nach vollständiger Ladung 
-    if (this->setreference > 0)
+    if (this->setreference > 0) // && this->voltage > 4000
     {
       this->percentage = 100;
       if ((millis() - this->correction) > CORRECTIONTIME)
@@ -146,8 +147,12 @@ void Battery::updatePowerPercentage()
       }
       else 
       {
+      // Gleitender Mittelwert / Filter
         int FF = 2;
-        this->percentage = ceil(((this->percentage * FF) + percraw) / (FF +1.0));
+        float newPerc = ((this->percentage * FF) + percraw) / (FF + 1.0);
+        
+        // Endwert wieder auf 0–100% begrenzen
+        this->percentage = constrain(newPerc, 0, 100);
       }
     }
     break;


### PR DESCRIPTION
## Summary

- Adds configurable inactivity timeout to the TFT display (OFF / 30 s / 60 s / 120 s / 300 s)
- Display dims to a configurable standby brightness (default: 5%) after the timeout; first touch wakes it up without forwarding the tap to LVGL (`ignoreTouchUntilRelease` guard)
- Display settings screen gains a second tab with +/− buttons to select the timeout value
- Timeout and standby brightness are persisted to NVS via `DisplayBase::saveConfig()` on dialog close
- Fixes battery percentage calculation: updated polynomial coefficients, `float` arithmetic, `constrain()` guard; `PowerMode::Protection` now handled the same as `PowerMode::Battery`
- Fixes battery icon symbol mapping: ceiling division replaces `map()` to prevent index underflow at 0%

## Changes

| File | Change |
|------|--------|
| `DisplayBase.h/.cpp` | New `timeoutbrightness` field; `timeout` widened to `uint32_t`; both persisted to NVS |
| `DisplayTft.h/.cpp` | `applyBrightness()` / `setUserBrightness()` split; `updateFade()`, `handleDisplayTimeout()`, `onUserActivity()`; `touchRead()` made instance-aware via `indev_drv.user_data` |
| `lvDisplay.h/.cpp` | Second tab (timeout +/−); `tabview` promoted to struct member; unused struct members removed |
| `Battery.cpp` | Updated polynomial, `float percraw`, `constrain()`, `PowerMode::Protection` case, voltage guard for `setreference` |
| `lvHome.cpp` | Ceiling-division battery symbol index |

## Code review fixes (on top of rebase onto `next`)

- Fixed wrong comment `"30000 s"` → `"300 s"` in `TIMEOUT_VALUES`
- Removed unused `LV_FONT_DECLARE(Font_Roboto_Medium_h80)`
- Removed dead struct members (`btnClose`, `labelBrightness`, `btnDec`, `btnInc`) from `lvDisplayType`
- Replaced `Serial.printf` with `Log.notice` in `initDisplay()`
- Cleaned up trailing whitespace and missing newline at EOF

## Test plan

- [ ] Build for miniV3 (`pio run -e miniV3`) passes without errors
- [ ] Display dims after configured timeout on real hardware
- [ ] First touch after timeout wakes display without triggering a UI action
- [ ] Timeout setting persists across reboot (NVS save on dialog close)
- [ ] Timeout = OFF disables standby entirely
- [ ] Battery percentage and icon display correctly at 0%, 50%, 100%